### PR TITLE
Post 삭제 시 Transaction처리 + 연관된 comment, image 처리

### DIFF
--- a/timeline/src/main/java/com/webapp/timeline/sns/repository/CommentsRepository.java
+++ b/timeline/src/main/java/com/webapp/timeline/sns/repository/CommentsRepository.java
@@ -14,6 +14,11 @@ import javax.transaction.Transactional;
 @Repository
 public interface CommentsRepository extends JpaRepository<Comments, Long> {
 
+    @Modifying
+    @Query(value = "UPDATE Comments item SET item.deleted = 1 " +
+                    "WHERE item.postId = :postId AND item.deleted = 0")
+    Integer markDeleteByPostId(@Param("postId") int postId);
+
     @Transactional
     @Modifying(clearAutomatically = true)
     @Query(value = "UPDATE Comments item SET item.deleted = :#{#comment.deleted} " +

--- a/timeline/src/main/java/com/webapp/timeline/sns/repository/ImagesRepository.java
+++ b/timeline/src/main/java/com/webapp/timeline/sns/repository/ImagesRepository.java
@@ -2,6 +2,7 @@ package com.webapp.timeline.sns.repository;
 
 import com.webapp.timeline.sns.domain.Images;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
@@ -11,6 +12,13 @@ import java.util.List;
 @Repository
 public interface ImagesRepository extends JpaRepository<Images, Long> {
 
-    @Query(value = "SELECT i FROM Images i WHERE i.postId = :postId AND i.deleted = 0")
+    @Query(value = "SELECT i FROM Images i " +
+                "WHERE i.postId = :postId AND i.deleted = 0")
     List<Images> listImageListInPost(@Param("postId") int postId);
+
+    @Modifying
+    @Query(value = "UPDATE Images i SET i.deleted = 1 " +
+                "WHERE i.postId = :postId AND i.deleted = 0")
+    Integer markDeleteByPostId(@Param("postId") int postId);
+
 }

--- a/timeline/src/main/java/com/webapp/timeline/sns/repository/PostsRepository.java
+++ b/timeline/src/main/java/com/webapp/timeline/sns/repository/PostsRepository.java
@@ -14,7 +14,6 @@ import javax.transaction.Transactional;
 @Repository
 public interface PostsRepository extends JpaRepository<Posts, Integer> {
 
-    @Transactional
     @Modifying(clearAutomatically = true)
     @Query(value = "UPDATE Posts p SET p.deleted = :#{#post.deleted} " +
                     "WHERE p.postId = :#{#post.postId}",

--- a/timeline/src/main/java/com/webapp/timeline/sns/service/CommentServiceImpl.java
+++ b/timeline/src/main/java/com/webapp/timeline/sns/service/CommentServiceImpl.java
@@ -70,10 +70,16 @@ public class CommentServiceImpl implements CommentService {
     }
 
     @Override
+    public int removeCommentByPostId(int postId) {
+        logger.info("[CommentService] remove all-comments by postId.");
+
+        return this.commentsRepository.markDeleteByPostId(postId);
+    }
+
+    @Override
     public Map<String, Integer> removeComment(long commentId, HttpServletRequest request) {
         logger.info("[CommentService] remove comment.");
         String author;
-        int affectedRow;
 
         author = this.userSignServiceImpl.extractUserFromToken(request)
                                         .getUserId();
@@ -85,8 +91,7 @@ public class CommentServiceImpl implements CommentService {
         if(author.equals(comment.getAuthor())) {
             comment.setDeleted(DELETED_EVENT_CHECK);
 
-            affectedRow = this.commentsRepository.markDeleteByCommentId(comment);
-            factory.takeActionByQuery(comment, affectedRow);
+            factory.takeActionByQuery(this.commentsRepository.markDeleteByCommentId(comment));
             return Collections.singletonMap("commentId", (int)commentId);
         }
         else
@@ -97,7 +102,6 @@ public class CommentServiceImpl implements CommentService {
     public CommentResponse editComment(long commentId, Comments comment, HttpServletRequest request) {
         logger.info("[CommentService] edit comment.");
         String author;
-        int affectedRow;
 
         author = this.userSignServiceImpl.extractUserFromToken(request)
                                         .getUserId();
@@ -115,8 +119,8 @@ public class CommentServiceImpl implements CommentService {
             existedComment.setContent(comment.getContent());
             existedComment.setLastUpdate(factory.whatIsTimestampOfNow());
 
-            affectedRow = this.commentsRepository.editCommentByCommentId(existedComment);
-            return makeSingleResponse(factory.takeActionByQuery(existedComment, affectedRow));
+            factory.takeActionByQuery(this.commentsRepository.editCommentByCommentId(existedComment));
+            return makeSingleResponse(existedComment);
         }
         else
             throw new UnauthorizedUserException();

--- a/timeline/src/main/java/com/webapp/timeline/sns/service/ImageServiceImpl.java
+++ b/timeline/src/main/java/com/webapp/timeline/sns/service/ImageServiceImpl.java
@@ -4,6 +4,7 @@ import com.webapp.timeline.exception.NoStoringException;
 import com.webapp.timeline.exception.WrongCodeException;
 import com.webapp.timeline.membership.service.UserSignService;
 import com.webapp.timeline.membership.service.UserSignServiceImpl;
+import com.webapp.timeline.sns.domain.Images;
 import com.webapp.timeline.sns.dto.ImageDto;
 import com.webapp.timeline.sns.repository.ImagesRepository;
 import com.webapp.timeline.sns.service.interfaces.ImageService;
@@ -72,6 +73,20 @@ public class ImageServiceImpl implements ImageService {
         }
 
         return null;
+    }
+
+    @Override
+    public void saveImage(Images entity) {
+        logger.info("[ImageService] Save image to database.");
+
+        imagesRepository.save(entity);
+    }
+
+    @Override
+    public int deleteImageByPostId(int postId) {
+        logger.info("[ImageService] Delete all-images by postId.");
+
+        return this.imagesRepository.markDeleteByPostId(postId);
     }
 
     private String makeThumbNail(File original, String email) {

--- a/timeline/src/main/java/com/webapp/timeline/sns/service/ServiceAspectFactory.java
+++ b/timeline/src/main/java/com/webapp/timeline/sns/service/ServiceAspectFactory.java
@@ -25,12 +25,10 @@ public class ServiceAspectFactory<T> {
         return Timestamp.valueOf(now);
     }
 
-    protected T takeActionByQuery(T object, int affectedRow) {
+    protected void takeActionByQuery(int affectedRow) {
         if(affectedRow == 0) {
             throw new WrongCodeException();
         }
-
-        return object;
     }
 
     protected void checkContentLength(String content, int maxLength) {

--- a/timeline/src/main/java/com/webapp/timeline/sns/service/interfaces/CommentService.java
+++ b/timeline/src/main/java/com/webapp/timeline/sns/service/interfaces/CommentService.java
@@ -12,6 +12,8 @@ import java.util.Map;
 public interface CommentService {
     CommentResponse registerComment(int postId, Comments comment, HttpServletRequest request);
 
+    int removeCommentByPostId(int postId);
+
     Map<String, Integer> removeComment(long commentId, HttpServletRequest request);
 
     CommentResponse editComment(long commentId, Comments comment, HttpServletRequest request);

--- a/timeline/src/main/java/com/webapp/timeline/sns/service/interfaces/ImageService.java
+++ b/timeline/src/main/java/com/webapp/timeline/sns/service/interfaces/ImageService.java
@@ -1,5 +1,6 @@
 package com.webapp.timeline.sns.service.interfaces;
 
+import com.webapp.timeline.sns.domain.Images;
 import com.webapp.timeline.sns.dto.ImageDto;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -7,4 +8,8 @@ import javax.servlet.http.HttpServletRequest;
 
 public interface ImageService {
     ImageDto uploadImage(MultipartFile file, HttpServletRequest request);
+
+    void saveImage(Images entity);
+
+    int deleteImageByPostId(int postId);
 }


### PR DESCRIPTION
1. transaction 범위를 post, comment, image를 포용하도록 수정
2. post delete 하면 연결된 comment, image까지 삭제되게 하기