### PR TITLE
코드 리팩토링 : follow 리스트 받아오는 메소드 관련, Timeline response

### DIFF
--- a/timeline/src/main/java/com/webapp/timeline/sns/domain/Posts.java
+++ b/timeline/src/main/java/com/webapp/timeline/sns/domain/Posts.java
@@ -39,10 +39,4 @@ public class Posts {
     @Column(name = "deleted")
     private int deleted;
 
-    @Formula("(select count(*) from comments c where c.postId = postId AND c.deleted = 0)")
-    private Long commentNum;
-
-    @Formula("(select count(*) from likes l where l.postId = postId)")
-    private Long likeNum;
-
 }

--- a/timeline/src/main/java/com/webapp/timeline/sns/repository/CommentsRepository.java
+++ b/timeline/src/main/java/com/webapp/timeline/sns/repository/CommentsRepository.java
@@ -38,4 +38,7 @@ public interface CommentsRepository extends JpaRepository<Comments, Long> {
     @Query(value = "SELECT list FROM Comments list WHERE list.deleted = 0 AND list.postId = :postId",
             nativeQuery = false)
     Page<Comments> listValidCommentsByPostId(Pageable pageable, @Param("postId") int postId);
+
+    @Query(value = "SELECT COUNT(list.commentId) FROM Comments list WHERE list.deleted = 0 AND list.postId = :postId")
+    Long countCommentsByPostId(@Param("postId") int postId);
 }

--- a/timeline/src/main/java/com/webapp/timeline/sns/repository/LikesRepository.java
+++ b/timeline/src/main/java/com/webapp/timeline/sns/repository/LikesRepository.java
@@ -17,4 +17,7 @@ public interface LikesRepository extends JpaRepository<Likes, Long> {
 
     @Query(value = "SELECT heart.owner FROM Likes heart WHERE heart.postId = :postId")
     Page<String> showLikesByPostId(Pageable pageable, @Param("postId") int postId);
+
+    @Query(value = "SELECT COUNT(heart.likeId) FROM Likes heart WHERE heart.postId = :postId")
+    Long countLikesByPostId(@Param("postId") int postId);
 }

--- a/timeline/src/main/java/com/webapp/timeline/sns/service/PostServiceImpl.java
+++ b/timeline/src/main/java/com/webapp/timeline/sns/service/PostServiceImpl.java
@@ -1,7 +1,6 @@
 package com.webapp.timeline.sns.service;
 
 import com.webapp.timeline.exception.*;
-import com.webapp.timeline.sns.common.ShowTypeProvider;
 import com.webapp.timeline.sns.domain.Images;
 import com.webapp.timeline.sns.domain.Posts;
 import com.webapp.timeline.sns.domain.Tags;
@@ -69,7 +68,9 @@ public class PostServiceImpl implements PostService {
         Map<String, Integer> responseBody = new HashMap<>(2);
         AtomicInteger count = new AtomicInteger();
         String author = factory.extractLoggedIn(request);
+
         checkContentValidation(postRequest);
+
         int postId = postsRepository.save(makeObjectForPost(postRequest, author))
                                     .getPostId();
 
@@ -159,7 +160,7 @@ public class PostServiceImpl implements PostService {
                 throw new BadRequestException();
             }
             else if(showLevel.equals(FOLLOWER_TYPE.getName())
-                    && !factory.isMyFriend(loggedIn, author)) {
+                    && !factory.isFollowedMe(loggedIn, author)) {
                 throw new BadRequestException();
             }
         }

--- a/timeline/src/main/java/com/webapp/timeline/sns/service/ServiceAspectFactory.java
+++ b/timeline/src/main/java/com/webapp/timeline/sns/service/ServiceAspectFactory.java
@@ -21,7 +21,7 @@ import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.Collections;
-import java.util.Map;
+import java.util.List;
 
 import static com.webapp.timeline.sns.common.CommonTypeProvider.DELETED_EVENT_CHECK;
 
@@ -76,6 +76,25 @@ public class ServiceAspectFactory<T> {
         return new LoggedInfo(userId, profile, user.getName(), user.getComment());
     }
 
+    protected boolean isFollowedMe(String loggedIn, String author) {
+        try {
+            return this.friendService.sendFollowIdList(author, false)
+                                     .contains(loggedIn);
+        }
+        catch(NoMatchPointException no_friend) {
+            return false;
+        }
+    }
+
+    protected List whoFollowsMe(String me) {
+        try {
+            return this.friendService.sendFollowIdList(me, false);
+        }
+        catch(NoMatchPointException no_one) {
+            return Collections.EMPTY_LIST;
+        }
+    }
+
     protected Posts checkDeleteAndGetIfExist(int postId) {
         Posts post = this.postsRepository.findById(postId)
                                         .orElseThrow(NoInformationException::new);
@@ -121,15 +140,5 @@ public class ServiceAspectFactory<T> {
             return true;
         }
         return false;
-    }
-
-    protected boolean isMyFriend(String loggedIn, String author) {
-        try {
-            return this.friendService.sendFollowIdList(author, false)
-                                     .contains(loggedIn);
-        }
-        catch(NoMatchPointException no_friend) {
-            return false;
-        }
     }
 }

--- a/timeline/src/main/java/com/webapp/timeline/sns/service/interfaces/SnsResponseHelper.java
+++ b/timeline/src/main/java/com/webapp/timeline/sns/service/interfaces/SnsResponseHelper.java
@@ -7,7 +7,7 @@ import org.springframework.data.domain.Page;
 
 import java.util.LinkedList;
 
-public interface TimelineResponseHelper {
+public interface SnsResponseHelper {
 
     TimelineResponse makeSingleResponse(Posts post);
 


### PR DESCRIPTION
1. follow 리스트에 사용자가 있는지 검사하는 메소드 - rename
2. follow 리스트만 받아오는 메소드 추가 --> 하는 일 분리를 위해 메소드를 따로 구현
3. Timeline response에서 댓글/ 좋아요 개수 받아오는 일을 post vo와 분리시킴