### PR TITLE
메인 페이지 : 뉴스피드 구현 완료

### DIFF
--- a/timeline/src/main/java/com/webapp/timeline/sns/common/CommonTypeProvider.java
+++ b/timeline/src/main/java/com/webapp/timeline/sns/common/CommonTypeProvider.java
@@ -7,4 +7,12 @@ public final class CommonTypeProvider {
     public static final int NEW_EVENT_CHECK = 0;
 
     public static final int DELETED_EVENT_CHECK = 1;
+
+    public static final String NEWSFEED_POST = "post";
+
+    public static final String NEWSFEED_COMMENT = "comment";
+
+    public static final String NEWSFEED_LIKE = "like";
+
+    public static final long NOT_COMMENT = 0;
 }

--- a/timeline/src/main/java/com/webapp/timeline/sns/domain/Newsfeed.java
+++ b/timeline/src/main/java/com/webapp/timeline/sns/domain/Newsfeed.java
@@ -1,0 +1,37 @@
+package com.webapp.timeline.sns.domain;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+@Entity
+@Table(name = "newsfeed")
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class Newsfeed {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private long id;
+
+    @Column(name = "postId", nullable = false)
+    private int postId;
+
+    @Column(name = "category", nullable = false)
+    private String category;
+
+    @Column(name = "sender")
+    private String sender;
+
+    @Column(name = "receiver", nullable = false)
+    private String receiver;
+
+    @Column(name = "commentId")
+    private long commentId;
+
+}

--- a/timeline/src/main/java/com/webapp/timeline/sns/dto/response/NewsfeedResponse.java
+++ b/timeline/src/main/java/com/webapp/timeline/sns/dto/response/NewsfeedResponse.java
@@ -1,0 +1,26 @@
+package com.webapp.timeline.sns.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class NewsfeedResponse {
+
+    @JsonProperty("feed")
+    private TimelineResponse feed;
+
+    private String sender;
+
+    private String category;
+
+    @JsonProperty("comment")
+    private List<CommentResponse> comment;
+}

--- a/timeline/src/main/java/com/webapp/timeline/sns/repository/CommentsRepository.java
+++ b/timeline/src/main/java/com/webapp/timeline/sns/repository/CommentsRepository.java
@@ -10,6 +10,7 @@ import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import javax.transaction.Transactional;
+import java.util.List;
 
 @Repository
 public interface CommentsRepository extends JpaRepository<Comments, Long> {
@@ -19,7 +20,6 @@ public interface CommentsRepository extends JpaRepository<Comments, Long> {
                     "WHERE item.postId = :postId AND item.deleted = 0")
     Integer markDeleteByPostId(@Param("postId") int postId);
 
-    @Transactional
     @Modifying(clearAutomatically = true)
     @Query(value = "UPDATE Comments item SET item.deleted = :#{#comment.deleted} " +
                     "WHERE item.commentId = :#{#comment.commentId} AND item.deleted = 0",
@@ -41,4 +41,9 @@ public interface CommentsRepository extends JpaRepository<Comments, Long> {
 
     @Query(value = "SELECT COUNT(list.commentId) FROM Comments list WHERE list.deleted = 0 AND list.postId = :postId")
     Long countCommentsByPostId(@Param("postId") int postId);
+
+    @Transactional
+    @Query(value = "SELECT list FROM Comments list WHERE list.deleted = 0 AND list.postId = :postId",
+            nativeQuery = false)
+    List<Comments> getCommentsByPostId(@Param("postId") int postId);
 }

--- a/timeline/src/main/java/com/webapp/timeline/sns/repository/NewsfeedRepository.java
+++ b/timeline/src/main/java/com/webapp/timeline/sns/repository/NewsfeedRepository.java
@@ -1,0 +1,32 @@
+package com.webapp.timeline.sns.repository;
+
+import com.webapp.timeline.sns.domain.Newsfeed;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface NewsfeedRepository extends JpaRepository<Newsfeed, Long> {
+
+    @Query(value = "SELECT list FROM Newsfeed list WHERE list.receiver = :receiver",
+            nativeQuery = false)
+    Page<Newsfeed> getNewsfeedByReceiver(Pageable pageable, @Param("receiver") String receiver);
+
+    @Modifying
+    @Query(value = "DELETE FROM Newsfeed list WHERE list.postId = :postId",
+            nativeQuery = false)
+    void deleteNewsfeedByPostId(@Param("postId") int postId);
+
+    @Modifying
+    @Query(value = "DELETE FROM Newsfeed list WHERE list.sender = :sender AND list.commentId = :commentId",
+            nativeQuery = false)
+    void deleteNewsfeedByComment(@Param("sender") String sender, @Param("commentId") long commentId);
+
+    @Modifying
+    @Query(value = "DELETE FROM Newsfeed list " +
+                   "WHERE list.postId = :postId AND list.sender = :sender AND list.category = :category",
+            nativeQuery = false)
+    void deleteNewsfeedByLike(@Param("postId") int postId, @Param("sender") String sender, @Param("category") String category);
+}

--- a/timeline/src/main/java/com/webapp/timeline/sns/repository/PostsRepository.java
+++ b/timeline/src/main/java/com/webapp/timeline/sns/repository/PostsRepository.java
@@ -10,6 +10,7 @@ import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import javax.transaction.Transactional;
+import java.util.List;
 
 @Repository
 public interface PostsRepository extends JpaRepository<Posts, Integer> {
@@ -37,4 +38,8 @@ public interface PostsRepository extends JpaRepository<Posts, Integer> {
     @Query(value = "SELECT COUNT(list) FROM Posts list WHERE list.deleted = 0 AND list.author = :author",
             nativeQuery = false)
     Long showPostNumberByUser(@Param("author") String author);
+
+    @Query(value = "SELECT list.postId FROM Posts list WHERE list.deleted = 1",
+            nativeQuery = false)
+    List<Integer> getDeletedPostList();
 }

--- a/timeline/src/main/java/com/webapp/timeline/sns/service/ImageServiceImpl.java
+++ b/timeline/src/main/java/com/webapp/timeline/sns/service/ImageServiceImpl.java
@@ -33,8 +33,8 @@ public class ImageServiceImpl implements ImageService {
     private ImagesRepository imagesRepository;
     private UserSignService userSignService;
     private ServiceAspectFactory<Images> factory;
-    private final int THUMBNAIL_HEIGHT = 330;
-    private final int THUMBNAIL_WIDTH = 330;
+    private final int THUMBNAIL_HEIGHT = 250;
+    private final int THUMBNAIL_WIDTH = 250;
     private final String IMAGE_FORMAT = "png";
     private final String TEMP_FILEPATH = "src/main/resources/thumbnail.png";
 

--- a/timeline/src/main/java/com/webapp/timeline/sns/service/NewsfeedServiceImpl.java
+++ b/timeline/src/main/java/com/webapp/timeline/sns/service/NewsfeedServiceImpl.java
@@ -1,0 +1,125 @@
+package com.webapp.timeline.sns.service;
+
+import com.webapp.timeline.exception.BadRequestException;
+import com.webapp.timeline.exception.NoInformationException;
+import com.webapp.timeline.exception.NoStoringException;
+import com.webapp.timeline.sns.domain.Comments;
+import com.webapp.timeline.sns.domain.Newsfeed;
+import com.webapp.timeline.sns.domain.Posts;
+import com.webapp.timeline.sns.dto.response.CommentResponse;
+import com.webapp.timeline.sns.dto.response.NewsfeedResponse;
+import com.webapp.timeline.sns.dto.response.SnsResponse;
+import com.webapp.timeline.sns.dto.response.TimelineResponse;
+import com.webapp.timeline.sns.repository.CommentsRepository;
+import com.webapp.timeline.sns.repository.NewsfeedRepository;
+import com.webapp.timeline.sns.service.interfaces.NewsfeedService;
+import com.webapp.timeline.sns.service.interfaces.SnsResponseHelper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+import javax.servlet.http.HttpServletRequest;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Objects;
+
+import static com.webapp.timeline.sns.common.CommonTypeProvider.NEWSFEED_COMMENT;
+
+@Service
+public class NewsfeedServiceImpl implements NewsfeedService, SnsResponseHelper<NewsfeedResponse, Newsfeed> {
+
+    private static final Logger logger = LoggerFactory.getLogger(NewsfeedServiceImpl.class);
+    private NewsfeedRepository newsfeedRepository;
+    private CommentsRepository commentsRepository;
+    private TimelineServiceImpl timelineService;
+    private ServiceAspectFactory<Newsfeed> factory;
+
+    NewsfeedServiceImpl() {
+    }
+
+    @Autowired
+    NewsfeedServiceImpl(NewsfeedRepository newsfeedRepository,
+                        CommentsRepository commentsRepository,
+                        TimelineServiceImpl timelineService,
+                        ServiceAspectFactory<Newsfeed> factory) {
+        this.newsfeedRepository = newsfeedRepository;
+        this.commentsRepository = commentsRepository;
+        this.timelineService = timelineService;
+        this.factory = factory;
+    }
+
+    @Override
+    public SnsResponse<NewsfeedResponse> dispatch(Pageable pageable,
+                                                  HttpServletRequest request) {
+        logger.info("[NewsfeedService] dispatch list.");
+
+        String loggedIn = factory.extractLoggedIn(request);
+        factory.checkInactiveUser(loggedIn);
+
+        Page<Newsfeed> feedList = newsfeedRepository.getNewsfeedByReceiver(pageable, loggedIn);
+
+        if(factory.isPageExceed(feedList, pageable)) {
+            throw new BadRequestException();
+        }
+
+        return makeSnsResponse(feedList);
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public NewsfeedResponse makeSingleResponse(Newsfeed newsfeed) {
+        Posts post = null;
+        LinkedList<CommentResponse> selectedComments = new LinkedList<>();
+
+        try {
+            post = factory.checkDeleteAndGetIfExist(newsfeed.getPostId());
+        }
+        catch(NoInformationException deleted_post) {
+            throw new NoStoringException();
+        }
+
+        int postId = Objects.requireNonNull(post, "post already deleted.")
+                            .getPostId();
+
+        LinkedList tags = (LinkedList) timelineService.getPostTags(postId);
+        String category = newsfeed.getCategory();
+        List<Comments> postComments = commentsRepository.getCommentsByPostId(postId);
+
+        if(category.equals(NEWSFEED_COMMENT)) {
+            postComments.forEach(comment -> {
+                if(!comment.getAuthor().equals(newsfeed.getSender())) {
+                    return;
+                }
+
+                selectedComments.add(CommentResponse.builder()
+                                                    .postId(postId)
+                                                    .profile(factory.makeSingleProfile(newsfeed.getSender()))
+                                                    .content(comment.getContent())
+                                                    .timestamp(timelineService.printEasyTimestamp(comment.getLastUpdate()))
+                                                    .build());
+            });
+        }
+
+        TimelineResponse feed = TimelineResponse.builder()
+                                                .postId(postId)
+                                                .profile(factory.makeSingleProfile(post.getAuthor()))
+                                                .content(post.getContent())
+                                                .showLevel(post.getShowLevel())
+                                                .timestamp(timelineService.printEasyTimestamp(post.getLastUpdate()))
+                                                .files(timelineService.getPostImages(postId))
+                                                .tags(tags)
+                                                .totalTag(tags.size())
+                                                .totalComment(postComments.size())
+                                                .totalLike((int) timelineService.countPostLikes(postId))
+                                                .build();
+        return NewsfeedResponse.builder()
+                                .feed(feed)
+                                .sender(newsfeed.getSender())
+                                .category(category)
+                                .comment(selectedComments)
+                                .build();
+    }
+}

--- a/timeline/src/main/java/com/webapp/timeline/sns/service/interfaces/NewsfeedService.java
+++ b/timeline/src/main/java/com/webapp/timeline/sns/service/interfaces/NewsfeedService.java
@@ -1,0 +1,12 @@
+package com.webapp.timeline.sns.service.interfaces;
+
+import com.webapp.timeline.sns.dto.response.NewsfeedResponse;
+import com.webapp.timeline.sns.dto.response.SnsResponse;
+import org.springframework.data.domain.Pageable;
+
+import javax.servlet.http.HttpServletRequest;
+
+public interface NewsfeedService {
+
+    SnsResponse<NewsfeedResponse> dispatch(Pageable pageable, HttpServletRequest request);
+}

--- a/timeline/src/main/java/com/webapp/timeline/sns/service/interfaces/SnsResponseHelper.java
+++ b/timeline/src/main/java/com/webapp/timeline/sns/service/interfaces/SnsResponseHelper.java
@@ -1,24 +1,22 @@
 package com.webapp.timeline.sns.service.interfaces;
 
-import com.webapp.timeline.sns.domain.Posts;
 import com.webapp.timeline.sns.dto.response.SnsResponse;
-import com.webapp.timeline.sns.dto.response.TimelineResponse;
 import org.springframework.data.domain.Page;
 
 import java.util.LinkedList;
 
-public interface SnsResponseHelper {
+public interface SnsResponseHelper<T, M> {
 
-    TimelineResponse makeSingleResponse(Posts post);
+    T makeSingleResponse(M item);
 
-    default SnsResponse<TimelineResponse> makeSnsResponse(Page<Posts> pagedList) {
-        LinkedList<TimelineResponse> eventList = new LinkedList<>();
+    default SnsResponse<T> makeSnsResponse(Page<M> pagedList) {
+        LinkedList<T> eventList = new LinkedList<>();
 
         pagedList.forEach(item -> {
             eventList.add(makeSingleResponse(item));
         });
 
-        return SnsResponse.<TimelineResponse>builder()
+        return SnsResponse.<T>builder()
                             .objectSet(eventList)
                             .first(pagedList.isFirst())
                             .last(pagedList.isLast())

--- a/timeline/src/main/java/com/webapp/timeline/sns/web/NewsfeedController.java
+++ b/timeline/src/main/java/com/webapp/timeline/sns/web/NewsfeedController.java
@@ -1,0 +1,82 @@
+package com.webapp.timeline.sns.web;
+
+import com.webapp.timeline.exception.BadRequestException;
+import com.webapp.timeline.exception.NoInformationException;
+import com.webapp.timeline.exception.NoStoringException;
+import com.webapp.timeline.exception.UnauthorizedUserException;
+import com.webapp.timeline.sns.dto.request.CustomPageRequest;
+import com.webapp.timeline.sns.service.NewsfeedServiceImpl;
+import com.webapp.timeline.sns.service.interfaces.NewsfeedService;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.servlet.http.HttpServletRequest;
+
+@Api(tags = {"6. Timeline"})
+@RestController
+@CrossOrigin(origins = {"*"})
+@RequestMapping(value = "/api")
+public class NewsfeedController {
+
+    private static final Logger logger = LoggerFactory.getLogger(NewsfeedController.class);
+    private NewsfeedService newsfeedService;
+    private HttpHeaders header;
+
+    NewsfeedController() {
+        header = new HttpHeaders();
+        header.setContentType(MediaType.APPLICATION_JSON_UTF8);
+    }
+
+    @Autowired
+    NewsfeedController(NewsfeedServiceImpl newsfeedService) {
+        this.newsfeedService = newsfeedService;
+    }
+
+    @ApiOperation(value = "메인페이지 (request: 몇 페이지)",
+            notes = "response : 200 -> 성공 " +
+                    "| 400 -> 페이지 번호 > 마지막 페이지 일때 " +
+                    "| 401 -> 로그인 안함/ 접근 권한 없을 때 " +
+                    "| 404 -> 비활성 계정으로 로그인함 " +
+                    "| 409 -> 삭제된 게시물 (페이지 불러오고 나서 삭제됨)")
+    @GetMapping(value = "/newsfeed")
+    public ResponseEntity newsfeed(CustomPageRequest pageRequest,
+                                   HttpServletRequest request) {
+        logger.info("[NewsfeedController] Main Page.");
+
+        try {
+            return new ResponseEntity<>
+                    (newsfeedService.dispatch(pageRequest.of("id"), request), header, HttpStatus.OK);
+        }
+        catch(BadRequestException exceed_page) {
+            logger.error("[NewsfeedController] Input page exceeds last page.");
+
+            return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
+        }
+        catch(UnauthorizedUserException no_user) {
+            logger.error("[NewsfeedController] No user.");
+
+            return new ResponseEntity<>(HttpStatus.UNAUTHORIZED);
+        }
+        catch(NoInformationException inactive_user) {
+            logger.warn("[NewsfeedController] Inactive User.");
+
+            return new ResponseEntity<>(HttpStatus.NOT_FOUND);
+        }
+        catch(NoStoringException deleted_post) {
+            logger.error("[NewsfeedController] Post alreay deleted.");
+
+            return new ResponseEntity<>(HttpStatus.CONFLICT);
+        }
+    }
+}


### PR DESCRIPTION
1. Newsfeed 도메인/ response dto 설계
2. repository -> 필요한 쿼리 구현
3. 메인페이지에서 사용자에 맞는 소식을 접할 수 있게 하는 service/ controller 구현
4. 부가적인 리팩토링