### PR TITLE
Newsfeed 저장/ read 로직 변경

### DIFF
--- a/timeline/src/main/java/com/webapp/timeline/sns/common/CommonTypeProvider.java
+++ b/timeline/src/main/java/com/webapp/timeline/sns/common/CommonTypeProvider.java
@@ -14,7 +14,7 @@ public final class CommonTypeProvider {
 
     public static final String NEWSFEED_LIKE = "like";
 
-    public static final int DEFAULT_FREQUENCY = 1;
+    public static final int NOT_COMMENT = 0;
 
     public static final int DISALLOW_ALARM = 0;
 

--- a/timeline/src/main/java/com/webapp/timeline/sns/domain/Newsfeed.java
+++ b/timeline/src/main/java/com/webapp/timeline/sns/domain/Newsfeed.java
@@ -29,11 +29,10 @@ public class Newsfeed {
     @Column(name = "receiver", nullable = false)
     private String receiver;
 
-    @Setter
-    @Column(name = "frequency")
-    private int frequency;
-
     @Column(name = "lastUpdate")
     private Timestamp lastUpdate;
+
+    @Column(name = "commentId", nullable = true)
+    private long commentId;
 
 }

--- a/timeline/src/main/java/com/webapp/timeline/sns/repository/NewsfeedRepository.java
+++ b/timeline/src/main/java/com/webapp/timeline/sns/repository/NewsfeedRepository.java
@@ -11,18 +11,18 @@ import org.springframework.data.repository.query.Param;
 public interface NewsfeedRepository extends JpaRepository<Newsfeed, Long> {
 
     @Modifying
-    @Query(value = "UPDATE Newsfeed news SET news.frequency = news.frequency+1, news.lastUpdate = :#{#news.lastUpdate} " +
-                    "WHERE news.postId = :#{#news.postId} AND news.category = :#{#news.category} " +
-                    "AND news.receiver = :#{#news.receiver} AND news.frequency >= 0")
-    Integer deliverLikeOrCommentNews(@Param("news") Newsfeed news);
+    @Query(value = "DELETE FROM Newsfeed list " +
+            "WHERE list.postId = :#{#news.postId} AND list.category = :#{#news.category} AND list.sender = :#{#news.sender}")
+    void deleteNewsfeedOfLike(@Param("news") Newsfeed news);
 
     @Modifying
-    @Query(value = "UPDATE Newsfeed news SET news.frequency = news.frequency-1 " +
-            "WHERE news.postId = :#{#news.postId} AND news.category = :#{#news.category} AND news.receiver = :#{#news.receiver}")
-    Integer withdrawLikeOrCommentNews(@Param("news") Newsfeed news);
+    @Query(value = "DELETE FROM Newsfeed list " +
+            "WHERE list.category = :#{#news.category} AND list.commentId = :#{#news.commentId}")
+    void deleteNewsfeedOfComment(@Param("news") Newsfeed news);
 
     @Query(value = "SELECT list FROM Newsfeed list " +
-                    "WHERE list.receiver = :receiver AND list.frequency > 0 ORDER BY list.lastUpdate DESC",
+            "WHERE list.id IN (SELECT MAX(f.id) FROM Newsfeed f WHERE f.receiver = :receiver GROUP BY f.postId) " +
+            "ORDER BY list.lastUpdate DESC",
             nativeQuery = false)
     Page<Newsfeed> getNewsfeedByReceiver(Pageable pageable, @Param("receiver") String receiver);
 

--- a/timeline/src/main/java/com/webapp/timeline/sns/service/CommentServiceImpl.java
+++ b/timeline/src/main/java/com/webapp/timeline/sns/service/CommentServiceImpl.java
@@ -52,7 +52,7 @@ public class CommentServiceImpl implements CommentService {
         factory.checkContentLength(content, MAXIMUM_CONTENT_LENGTH);
 
         Comments newComment = commentsRepository.save(makeObjectForComment(postId, content, loggedIn));
-        factory.deliverToNewsfeed(NEWSFEED_COMMENT, post, loggedIn);
+        factory.deliverToNewsfeed(NEWSFEED_COMMENT, post, loggedIn, newComment.getCommentId());
 
         return makeSingleResponse(newComment);
     }
@@ -77,12 +77,7 @@ public class CommentServiceImpl implements CommentService {
             comment.setDeleted(DELETED_EVENT_CHECK);
             factory.takeActionByQuery(this.commentsRepository.markDeleteByCommentId(comment));
 
-            try {
-                Posts relatedPost = factory.checkDeleteAndGetIfExist(comment.getPostId());
-                factory.withdrawFeedByLikeOrComment(NEWSFEED_COMMENT, relatedPost, loggedIn);
-            }
-            catch (NoInformationException ignored) {
-            }
+            factory.withdrawFeedByComment(commentId);
 
             return Collections.singletonMap("commentId", (int)commentId);
         }

--- a/timeline/src/main/java/com/webapp/timeline/sns/service/LikeServiceImpl.java
+++ b/timeline/src/main/java/com/webapp/timeline/sns/service/LikeServiceImpl.java
@@ -21,6 +21,7 @@ import java.util.LinkedList;
 import java.util.List;
 
 import static com.webapp.timeline.sns.common.CommonTypeProvider.NEWSFEED_LIKE;
+import static com.webapp.timeline.sns.common.CommonTypeProvider.NOT_COMMENT;
 
 @Service
 public class LikeServiceImpl implements LikeService {
@@ -55,7 +56,7 @@ public class LikeServiceImpl implements LikeService {
         if(likesRepository.isUserLikedPost(like) != null) {
             throw new BadRequestException();
         }
-        factory.deliverToNewsfeed(NEWSFEED_LIKE, post, loggedIn);
+        factory.deliverToNewsfeed(NEWSFEED_LIKE, post, loggedIn, NOT_COMMENT);
 
         likesRepository.save(like);
     }
@@ -76,13 +77,7 @@ public class LikeServiceImpl implements LikeService {
             throw new BadRequestException();
         }
 
-        try {
-            Posts relatedPost = factory.checkDeleteAndGetIfExist(postId);
-            factory.withdrawFeedByLikeOrComment(NEWSFEED_LIKE, relatedPost, loggedIn);
-        }
-        catch (NoInformationException ignored) {
-        }
-
+        factory.withdrawFeedByLike(postId, loggedIn);
         likesRepository.deleteById(likeId);
     }
 

--- a/timeline/src/main/java/com/webapp/timeline/sns/service/NewsfeedServiceImpl.java
+++ b/timeline/src/main/java/com/webapp/timeline/sns/service/NewsfeedServiceImpl.java
@@ -38,7 +38,7 @@ public class NewsfeedServiceImpl implements NewsfeedService, SnsResponseHelper<N
     private LikesRepository likesRepository;
     private TimelineServiceImpl timelineService;
     private ServiceAspectFactory<Newsfeed> factory;
-    private static final int MAX_PRINTED_USERS = 2;
+    private static final int MAX_PRINTED_USERS = 1;
 
     NewsfeedServiceImpl() {
     }
@@ -91,8 +91,6 @@ public class NewsfeedServiceImpl implements NewsfeedService, SnsResponseHelper<N
 
         LinkedList tags = (LinkedList) timelineService.getPostTags(postId);
         String category = newsfeed.getCategory();
-        List<Comments> postComments = commentsRepository.getCommentsByPostId(postId);
-        List<String> postLikes = likesRepository.getLikesByPostId(postId);
         LinkedList<CommentResponse> selectedComments = new LinkedList<>();
         String isLoggedInUserLikeIt = "block";
         Likes likeObject = Likes.builder()
@@ -105,10 +103,16 @@ public class NewsfeedServiceImpl implements NewsfeedService, SnsResponseHelper<N
             isLoggedInUserLikeIt = "none";
         }
 
-	int totalComment = postComments.size();
-	Boolean trueComment;
-	if(totalComment == 0) trueComment = false;
-	else trueComment = true;	
+        int totalComment = (int) timelineService.countPostComments(postId);
+	    boolean trueComment;
+
+	    if(totalComment == 0) {
+	        trueComment = false;
+        }
+	    else {
+	        trueComment = true;
+        }
+
         TimelineResponse feed = TimelineResponse.builder()
                                                 .postId(postId)
                                                 .profile(factory.makeSingleProfile(post.getAuthor()))
@@ -120,7 +124,7 @@ public class NewsfeedServiceImpl implements NewsfeedService, SnsResponseHelper<N
                                                 .tags(tags)
                                                 .totalTag(tags.size())
                                                 .totalComment(totalComment)
-                                                .totalLike(postLikes.size())
+                                                .totalLike((int) timelineService.countPostLikes(postId))
                                                 .isLoggedInUserLikeIt(isLoggedInUserLikeIt)
                                                 .commentState(DEFAULT_COMMENT_STATE)
                                                 .commentPage(DEFAULT_COMMENT_PAGE)
@@ -128,96 +132,45 @@ public class NewsfeedServiceImpl implements NewsfeedService, SnsResponseHelper<N
                                                 .isTrueComment(trueComment)
                                                 .build();
 
-        AtomicInteger index = new AtomicInteger();
-        AtomicReference senderNames = new AtomicReference("");
-
         String message = "";
-        List<String> myFollowList = factory.followsWho(loggedIn);
         LinkedList<Map<String, String>> senderInfoList = new LinkedList<>();
         Map<String, String> senderInfo;
 
         if(category.equals(NEWSFEED_COMMENT)) {
-            LinkedList<String> tempList = new LinkedList<>();
 
-            for (Comments comment : postComments) {
-                if (!myFollowList.contains(comment.getAuthor())) {
-                    continue;
-                }
-
-                ProfileResponse profile = factory.makeSingleProfile(comment.getAuthor());
-
-                selectedComments.add(CommentResponse.builder()
-                                .postId(postId)
-                                .profile(profile)
-                                .commentId(comment.getCommentId())
-                                .content(comment.getContent())
-                                .timestamp(new SimpleDateFormat(DEFAULT_DATE_FORMAT).format(comment.getLastUpdate().getTime()))
-                                .dateString("")
-                                .build());
-
-                if (tempList.size() > 0 && tempList.contains(comment.getAuthor())) {
-                    continue;
-                }
-
-                senderInfo = new HashMap<>(MAX_PRINTED_USERS);
-
-                senderInfo.put("username", comment.getAuthor());
-                senderInfo.put("nickname", profile.getName());
-                senderInfoList.add(senderInfo);
-
-                tempList.add(comment.getAuthor());
-
+            Optional<Comments> comment = commentsRepository.findById(newsfeed.getCommentId());
+            if(! comment.isPresent()) {
+                return null;
             }
 
-            for (Map<String, String> info : senderInfoList) {
-                if (index.get() == MAX_PRINTED_USERS - 1 && senderInfoList.size() > MAX_PRINTED_USERS - 1) {
-                    senderNames.set(senderNames + ", ");
-                }
+            ProfileResponse profile = factory.makeSingleProfile(comment.get().getAuthor());
 
-                senderNames.set(senderNames + info.get("nickname") + "님");
-                index.incrementAndGet();
-            }
+            selectedComments.add(CommentResponse.builder()
+                            .postId(postId)
+                            .profile(profile)
+                            .commentId(newsfeed.getCommentId())
+                            .content(comment.get().getContent())
+                            .timestamp(new SimpleDateFormat(DEFAULT_DATE_FORMAT).format(comment.get().getLastUpdate().getTime()))
+                            .dateString("")
+                            .build());
 
-            if (senderInfoList.size() <= MAX_PRINTED_USERS) {
-                message = senderNames.get() + "이 이 게시물에 댓글을 남겼습니다.";
-            }
-            else {
-                message = senderNames.get() + " 외 " + (senderInfoList.size() - MAX_PRINTED_USERS) + "명이 이 게시물에 댓글을 남겼습니다.";
-            }
+            senderInfo = new HashMap<>(MAX_PRINTED_USERS);
+
+            senderInfo.put("username", comment.get().getAuthor());
+            senderInfo.put("nickname", profile.getName());
+            senderInfoList.add(senderInfo);
+
+            message = profile.getName() + "님이 이 게시물에 댓글을 남겼습니다.";
         }
         else if (category.equals(NEWSFEED_LIKE)) {
+            String nickname = factory.loadUserById(newsfeed.getSender())
+                                    .getName();
+            senderInfo = new HashMap<>(MAX_PRINTED_USERS);
 
-            for (String owner : postLikes) {
-                if (!myFollowList.contains(owner)) {
-                    continue;
-                }
+            senderInfo.put("username", newsfeed.getSender());
+            senderInfo.put("nickname", nickname);
 
-                if (index.get() == MAX_PRINTED_USERS - 1) {
-                    senderNames.set(senderNames + ", ");
-                }
-
-                String nickname = factory.loadUserById(owner)
-                                         .getName();
-
-                senderInfo = new HashMap<>(MAX_PRINTED_USERS);
-
-                senderInfo.put("username", owner);
-                senderInfo.put("nickname", nickname);
-                senderInfoList.addLast(senderInfo);
-
-                if (index.get() <= MAX_PRINTED_USERS - 1) {
-                    senderNames.set(senderNames + nickname + "님");
-                }
-
-                index.getAndIncrement();
-            }
-
-            if (newsfeed.getFrequency() <= MAX_PRINTED_USERS) {
-                message = senderNames.get() + "이 이 게시물을 좋아합니다.";
-            }
-            else if (newsfeed.getFrequency() > MAX_PRINTED_USERS) {
-                message = senderNames.get() + "외 " + (newsfeed.getFrequency() - MAX_PRINTED_USERS) + "명이 이 게시물을 좋아합니다.";
-            }
+            message = nickname + "님이 이 게시물을 좋아합니다.";
         }
 
         return NewsfeedResponse.builder()

--- a/timeline/src/main/java/com/webapp/timeline/sns/service/PostServiceImpl.java
+++ b/timeline/src/main/java/com/webapp/timeline/sns/service/PostServiceImpl.java
@@ -193,8 +193,8 @@ public class PostServiceImpl implements PostService {
                                     .category(NEWSFEED_POST)
                                     .sender(sender)
                                     .receiver(sender)
-                                    .frequency(DEFAULT_FREQUENCY)
                                     .lastUpdate(factory.whatIsTimestampOfNow())
+                                    .commentId(NOT_COMMENT)
                                     .build());
             return;
         }
@@ -208,8 +208,8 @@ public class PostServiceImpl implements PostService {
                                     .category(NEWSFEED_POST)
                                     .sender(sender)
                                     .receiver(follower)
-                                    .frequency(DEFAULT_FREQUENCY)
                                     .lastUpdate(factory.whatIsTimestampOfNow())
+                                    .commentId(NOT_COMMENT)
                                     .build();
             factory.deliver(feed);
         });

--- a/timeline/src/main/java/com/webapp/timeline/sns/service/ServiceAspectFactory.java
+++ b/timeline/src/main/java/com/webapp/timeline/sns/service/ServiceAspectFactory.java
@@ -27,8 +27,7 @@ import java.util.Collections;
 import java.util.List;
 
 import static com.webapp.timeline.sns.common.CommonTypeProvider.*;
-import static com.webapp.timeline.sns.common.ShowTypeProvider.FOLLOWER_TYPE;
-import static com.webapp.timeline.sns.common.ShowTypeProvider.PUBLIC_TYPE;
+import static com.webapp.timeline.sns.common.ShowTypeProvider.*;
 
 @Service
 public class ServiceAspectFactory<T> {
@@ -116,7 +115,7 @@ public class ServiceAspectFactory<T> {
         return this.userSignService.loadUserByUsername(userId);
     }
 
-    void deliverToNewsfeed(String category, Posts post, String sender) {
+    void deliverToNewsfeed(String category, Posts post, String sender, long commentId) {
 
         computeReceivers(sender, post).forEach(follower -> {
             Newsfeed feed = Newsfeed.builder()
@@ -125,6 +124,7 @@ public class ServiceAspectFactory<T> {
                                     .sender(sender)
                                     .receiver(follower)
                                     .lastUpdate(whatIsTimestampOfNow())
+                                    .commentId(commentId)
                                     .build();
             deliver(feed);
         });
@@ -135,7 +135,7 @@ public class ServiceAspectFactory<T> {
         List<String> receivers = new ArrayList<>();
         List<String> followers = whoFollowsMe(sender);
 
-        if (post.getAuthor().equals(sender)) {
+        if (post.getAuthor().equals(sender) && !post.getShowLevel().equals(PRIVATE_TYPE.getName())) {
             receivers = followers;
         }
         else {
@@ -154,28 +154,28 @@ public class ServiceAspectFactory<T> {
     }
 
     void deliver(Newsfeed feed) {
-        int affectedRow = this.newsfeedRepository.deliverLikeOrCommentNews(feed);
-
-        if (affectedRow == 0) {
-            feed.setFrequency(DEFAULT_FREQUENCY);
-            newsfeedRepository.save(feed);
-        }
+        this.newsfeedRepository.save(feed);
     }
 
     void withdrawFeedByPostId(int postId) {
         this.newsfeedRepository.deleteNewsfeedByPostId(postId);
     }
 
-    void withdrawFeedByLikeOrComment(String category, Posts post, String sender) {
-
-        computeReceivers(sender, post).forEach(follower -> {
-            Newsfeed feed = Newsfeed.builder()
-                                    .postId(post.getPostId())
-                                    .category(category)
-                                    .receiver(follower)
+    void withdrawFeedByLike(int postId, String sender) {
+        Newsfeed newsfeed = Newsfeed.builder()
+                                    .postId(postId)
+                                    .category(NEWSFEED_LIKE)
+                                    .sender(sender)
                                     .build();
-            this.newsfeedRepository.withdrawLikeOrCommentNews(feed);
-        });
+        this.newsfeedRepository.deleteNewsfeedOfLike(newsfeed);
+    }
+
+    void withdrawFeedByComment(long commentId) {
+        Newsfeed newsfeed = Newsfeed.builder()
+                                    .category(NEWSFEED_COMMENT)
+                                    .commentId(commentId)
+                                    .build();
+        this.newsfeedRepository.deleteNewsfeedOfComment(newsfeed);
     }
 
     List whoFollowsMe(String me) {

--- a/timeline/src/main/java/com/webapp/timeline/sns/service/TimelineServiceImpl.java
+++ b/timeline/src/main/java/com/webapp/timeline/sns/service/TimelineServiceImpl.java
@@ -189,7 +189,7 @@ public class TimelineServiceImpl implements TimelineService, SnsResponseHelper<T
         return tagResponses;
     }
 
-    private long countPostComments(int postId) {
+    long countPostComments(int postId) {
         return this.commentsRepository.countCommentsByPostId(postId);
     }
 


### PR DESCRIPTION
#105 에서 제안한 개선사항 반영 완료함.

1. post/ comment/ like 등록 시 newsfeed에 deliver 하는 로직 변경
2. post/comment/like 삭제 시 newsfeed에서 withdraw 하는 로직 변경
3. newsfeed에서 소식들 읽을 때 게시글 별 중복 제거/ 최신 순 정렬