### PR TITLE
Unfollow 시 newsfeed에 반영 : 이전 기록까지 삭제하기

### DIFF
--- a/timeline/src/main/java/com/webapp/timeline/follow/service/UnFollowServiceImpl.java
+++ b/timeline/src/main/java/com/webapp/timeline/follow/service/UnFollowServiceImpl.java
@@ -8,11 +8,13 @@ import com.webapp.timeline.follow.service.interfaces.UnFollowService;
 import com.webapp.timeline.membership.repository.UsersEntityRepository;
 import com.webapp.timeline.membership.service.TokenService;
 import com.webapp.timeline.membership.service.interfaces.UserService;
+import com.webapp.timeline.sns.repository.NewsfeedRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.transaction.Transactional;
+
 @Service
 public class UnFollowServiceImpl implements UnFollowService {
     private TokenService tokenService;
@@ -20,16 +22,24 @@ public class UnFollowServiceImpl implements UnFollowService {
     private UsersEntityRepository usersEntityRepository;
     private FollowingRepository followingRepository;
     private FollowersRepository followersRepository;
+    private NewsfeedRepository newsfeedRepository;
 
     @Autowired
-    public UnFollowServiceImpl(TokenService tokenService,UserService userService,UsersEntityRepository usersEntityRepository,FollowersRepository followersRepository,FollowingRepository followingRepository){
+    public UnFollowServiceImpl(TokenService tokenService,
+                               UserService userService,
+                               UsersEntityRepository usersEntityRepository,
+                               FollowersRepository followersRepository,
+                               FollowingRepository followingRepository,
+                               NewsfeedRepository newsfeedRepository){
         this.followersRepository = followersRepository;
         this.followingRepository = followingRepository;
         this.tokenService = tokenService;
         this.userService = userService;
-        this.usersEntityRepository =usersEntityRepository;
+        this.usersEntityRepository = usersEntityRepository;
+        this.newsfeedRepository = newsfeedRepository;
     }
     public UnFollowServiceImpl(){}
+    
     @Transactional
     @Override
     public void sendUnFollow(String fid, HttpServletRequest request) throws RuntimeException{
@@ -41,6 +51,8 @@ public class UnFollowServiceImpl implements UnFollowService {
         try {
             followersRepository.updateUnfollow(userId, fid);
             followingRepository.updateUnfollow(userId, fid);
+
+            newsfeedRepository.deleteNewsfeedWhenUnfollow(fid, userId);
         }catch(Exception e){
             throw new NoStoringException();
         }

--- a/timeline/src/main/java/com/webapp/timeline/sns/repository/NewsfeedRepository.java
+++ b/timeline/src/main/java/com/webapp/timeline/sns/repository/NewsfeedRepository.java
@@ -31,4 +31,7 @@ public interface NewsfeedRepository extends JpaRepository<Newsfeed, Long> {
             nativeQuery = false)
     void deleteNewsfeedByPostId(@Param("postId") int postId);
 
+    @Modifying
+    @Query(value = "DELETE FROM Newsfeed list WHERE list.sender = :sender AND list.receiver = :receiver")
+    void deleteNewsfeedWhenUnfollow(@Param("sender") String sender, @Param("receiver") String receiver);
 }


### PR DESCRIPTION
#106 에서 제안된 개선사항 반영하였음.
기존 : unfollow 시 그 unfollow 시점부터 소식 받지 않기
변경 : unfollow 시 이전에 받았던 소식까지 뉴스피드에서 삭제하기